### PR TITLE
MG-128 Fix deadline without milliseconds part parsing

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 {deps, [
     {cowboy, "1.0.4"},
     {hackney, "1.6.2"},
-    {rfc3339, "0.2.2"},
+    {rfc3339, {git, "https://github.com/rbkmoney/rfc3339.git", {branch, "master"}}},
     {thrift, {git, "https://github.com/rbkmoney/thrift_erlang.git", {branch, "master"}}},
     {snowflake, {git, "https://github.com/rbkmoney/snowflake.git", {branch, "master"}}},
     {genlib, {git, "https://github.com/rbkmoney/genlib.git", {branch, "master"}}}

--- a/rebar.lock
+++ b/rebar.lock
@@ -11,7 +11,10 @@
  {<<"metrics">>,{pkg,<<"metrics">>,<<"1.0.1">>},1},
  {<<"mimerl">>,{pkg,<<"mimerl">>,<<"1.0.2">>},1},
  {<<"ranch">>,{pkg,<<"ranch">>,<<"1.3.2">>},1},
- {<<"rfc3339">>,{pkg,<<"rfc3339">>,<<"0.2.2">>},0},
+ {<<"rfc3339">>,
+  {git,"https://github.com/rbkmoney/rfc3339.git",
+       {ref,"ee3a1a6b1ee60219c49fdcaa9f36a25e91962bb5"}},
+  0},
  {<<"snowflake">>,
   {git,"https://github.com/rbkmoney/snowflake.git",
        {ref,"0a598108f6582affe3b4ae550fc5b9f2062e318a"}},
@@ -31,6 +34,5 @@
  {<<"metrics">>, <<"25F094DEA2CDA98213CECC3AEFF09E940299D950904393B2A29D191C346A8486">>},
  {<<"mimerl">>, <<"993F9B0E084083405ED8252B99460C4F0563E41729AB42D9074FD5E52439BE88">>},
  {<<"ranch">>, <<"E4965A144DC9FBE70E5C077C65E73C57165416A901BD02EA899CFD95AA890986">>},
- {<<"rfc3339">>, <<"1552DF616ACA368D982E9F085A0E933B6688A3F4938A671798978EC2C0C58730">>},
  {<<"ssl_verify_fun">>, <<"28A4D65B7F59893BC2C7DE786DEC1E1555BD742D336043FE644AE956C3497FBE">>}]}
 ].

--- a/src/woody_deadline.erl
+++ b/src/woody_deadline.erl
@@ -65,19 +65,14 @@ to_binary(Deadline = {{Date, Time}, Millisec}) ->
             erlang:error({bad_deadline, {Error, erlang:get_stacktrace()}}, [Deadline])
     end.
 
-%% Suppress dialyzer warning until rfc3339 spec will be fixed.
-%% see https://github.com/talentdeficit/rfc3339/pull/5
--dialyzer([{nowarn_function, [from_binary/1]}, no_match]).
 -spec from_binary(binary()) ->
     deadline().
 from_binary(Bin) ->
     case rfc3339:parse(Bin) of
-        {ok, {_Date, _Time, _Usec, TZ}} when TZ =/= 0 andalso TZ =/= undefined ->
-            erlang:error({bad_deadline, not_utc}, [Bin]);
-        {ok, {Date, Time, undefined, _TZ}} ->
-            {to_calendar_datetime(Date, Time), 0};
-        {ok, {Date, Time, Usec, _TZ}} ->
+        {ok, {Date, Time, Usec, TZ}} when TZ =:= 0 orelse TZ =:= undefined ->
             {to_calendar_datetime(Date, Time), Usec div 1000};
+        {ok, _} ->
+            erlang:error({bad_deadline, not_utc}, [Bin]);
         {error, Error} ->
             erlang:error({bad_deadline, Error}, [Bin])
     end.


### PR DESCRIPTION
Fix parsing deadlines with format like "2018-07-03T12:35:08Z".

Current implemetation raises an exception in code like
```woody_deadline:from_binary(woody_deadline:to_binary(woody_deadline:from_unixtime_ms(os:system_time(second) * 1000))).```