### PR TITLE
MSPF-392 Fix caching client events lack on transient errors

### DIFF
--- a/src/woody_client.erl
+++ b/src/woody_client.erl
@@ -61,6 +61,7 @@ call(Request, Options = #{event_handler := EvHandler}, Context) ->
 -spec call_safe(woody:request(), options(), woody_state:st()) ->
     result().
 call_safe(Request, Options, WoodyState) ->
+    _ = woody_event_handler:handle_event(?EV_CLIENT_BEGIN, WoodyState, #{}),
     try woody_client_behaviour:call(Request, Options, WoodyState) of
         Resp = {ok, _} ->
             Resp;
@@ -68,17 +69,21 @@ call_safe(Request, Options, WoodyState) ->
             Error
     catch
         Class:Reason ->
-            handle_client_error(Class, Reason, WoodyState)
+            StackTrace = erlang:get_stacktrace(),
+            handle_client_error(Class, Reason, StackTrace, WoodyState)
+    after
+        _ = woody_event_handler:handle_event(?EV_CLIENT_END, WoodyState, #{})
     end.
 
--spec handle_client_error(woody_error:erlang_except(), _Error, woody_state:st()) ->
+-spec handle_client_error(woody_error:erlang_except(), _Error, _StackTrace, woody_state:st()) ->
     {error, {system, {internal, result_unexpected, woody_error:details()}}}.
-handle_client_error(Class, Error, WoodyState) ->
+handle_client_error(Class, Error, StackTrace, WoodyState) ->
     Details = woody_error:format_details(Error),
     _ = woody_event_handler:handle_event(?EV_INTERNAL_ERROR, WoodyState, #{
-            error    => woody_util:to_binary([?EV_CALL_SERVICE, " error"]),
-            class    => Class,
-            reason   => Details,
-            stack    => erlang:get_stacktrace()
-        }),
+        error    => woody_util:to_binary([?EV_CALL_SERVICE, " error"]),
+        class    => Class,
+        reason   => Details,
+        stack    => StackTrace,
+        final    => false
+    }),
     {error, {system, {internal, result_unexpected, <<"client error: ", Details/binary>>}}}.

--- a/src/woody_defs.hrl
+++ b/src/woody_defs.hrl
@@ -42,13 +42,17 @@
 -define(EV_CALL_SERVICE           , 'call service').
 -define(EV_SERVICE_RESULT         , 'service result').
 
+-define(EV_CLIENT_BEGIN           , 'client begin').
 -define(EV_CLIENT_SEND            , 'client send').
 -define(EV_CLIENT_RECEIVE         , 'client receive').
+-define(EV_CLIENT_END             , 'client end').
 
+-define(EV_CLIENT_CACHE_BEGIN     , 'client cache begin').
 -define(EV_CLIENT_CACHE_HIT       , 'client cache hit').
 -define(EV_CLIENT_CACHE_MISS      , 'client cache miss').
 -define(EV_CLIENT_CACHE_UPDATE    , 'client cache update').
 -define(EV_CLIENT_CACHE_RESULT    , 'client cache result').
+-define(EV_CLIENT_CACHE_END       , 'client cache end').
 
 -define(EV_SERVER_RECEIVE         , 'server receive').
 -define(EV_SERVER_SEND            , 'server send').


### PR DESCRIPTION
Добавление событий начала и конца исходящего запроса.

События предназначены для того, чтобы пользователям событий woody не приходилось гадать, где начинается, а где заканчивается обработка запроса.