### PR TITLE
Fixed wrong timeout override logic

### DIFF
--- a/src/woody_client_thrift_http_transport.erl
+++ b/src/woody_client_thrift_http_transport.erl
@@ -127,11 +127,11 @@ set_timeouts(Options, Context) ->
             %% It is intentional, that application can override the timeout values
             %% calculated from the deadline (first option value in the list takes
             %% the precedence).
-            maps:merge(Options, #{
+            maps:merge(#{
                 connect_timeout => ConnectTimeout,
                 send_timeout =>    SendTimeout,
                 recv_timeout =>    Timeout
-            })
+            }, Options)
     end.
 
 -define(DEFAULT_CONNECT_AND_SEND_TIMEOUT, 1000). %% millisec


### PR DESCRIPTION
Пофиксил ошибку, допущенную при переводе сервиса на Erlang 21