### PR TITLE
MSPF-498: Handle terminate correctly

### DIFF
--- a/src/woody_server_thrift_http_handler.erl
+++ b/src/woody_server_thrift_http_handler.erl
@@ -331,8 +331,8 @@ create_dummy_state(EvHandler) ->
     ok.
 terminate(normal, _Req, _Status) ->
     ok;
-terminate(Reason, _Req, #{ev_handler := EvHandler} = State) ->
-    WoodyState = maps:get(woody_state, State, create_dummy_state(EvHandler)),
+terminate(Reason, _Req, #{ev_handler := EvHandler} = Opts) ->
+    WoodyState = maps:get(woody_state, Opts, create_dummy_state(EvHandler)),
     _ = woody_event_handler:handle_event(?EV_INTERNAL_ERROR, WoodyState, #{
             error  => <<"http handler terminated abnormally">>,
             reason => woody_error:format_details(Reason),


### PR DESCRIPTION
Похоже, что раньше мы [падали с `function_clause`](https://rbkmoney.atlassian.net/projects/MSPF/issues/MSPF-490) из-за отсутствия `woody_state` в случае ошибки инициализации.