### PR TITLE
Increase request id length limit up to 64

### DIFF
--- a/src/woody_context.erl
+++ b/src/woody_context.erl
@@ -186,7 +186,7 @@ make_ctx(RpcId = #{span_id := _, parent_id := _, trace_id := _}, Meta, Deadline)
 make_ctx(RpcId, Meta, Deadline) ->
     error(badarg, [RpcId, Meta, Deadline]).
 
-check_req_id_limit(_Type, Id) when is_binary(Id) andalso byte_size(Id) =< 32 ->
+check_req_id_limit(_Type, Id) when is_binary(Id) andalso byte_size(Id) =< 64 ->
     ok;
 check_req_id_limit(Type, Id) ->
     error(badarg, [Type, Id]).

--- a/test/property_test/woody_joint_workers_pt.erl
+++ b/test/property_test/woody_joint_workers_pt.erl
@@ -72,7 +72,7 @@ do(ID, Successfulness) ->
     catch woody_joint_workers:do(workers, {ID, Successfulness}, Task, woody_deadline:from_timeout(WorkerTimeout)).
 
 % если уменьшать, то могут быть ложные срабатывания
--define(timeout_k, 10).
+-define(timeout_k, 20).
 task_timeouts(success) ->
     {?timeout_k * 1, ?timeout_k * 3};
 task_timeouts(fail) ->


### PR DESCRIPTION
According to rbkmoney/coredocs#226.