### PR TITLE
feat: Add deadline opt for woody_client

### DIFF
--- a/src/woody.erl
+++ b/src/woody.erl
@@ -35,13 +35,14 @@
 %% Thrift
 -type service_name() :: atom().
 -type service() :: {module(), service_name()}.
+-type context() :: woody_context:ctx().
 -type func() :: atom().
 -type args() :: tuple().
 -type request() :: {service(), func(), args()}.
 -type result() :: _.
 -type th_handler() :: {service(), handler(options())}.
 
--export_type([request/0, result/0, service/0, service_name/0, func/0, args/0, th_handler/0]).
+-export_type([request/0, result/0, service/0, context/0, service_name/0, func/0, args/0, th_handler/0]).
 
 -type rpc_type() :: call | cast.
 


### PR DESCRIPTION
Позволит проставлять дедлайн в общем коде woody-клиента и избежать дупликаций вида:
https://github.com/rbkmoney/hellgate/blob/454939c7f20679daefb8838988fb65da2310ef78/apps/hg_proto/src/hg_woody_wrapper.erl#L70-L82